### PR TITLE
allow international linkedin.com subdomains

### DIFF
--- a/crosslinked/search.py
+++ b/crosslinked/search.py
@@ -118,7 +118,7 @@ class CrossLinked:
     def results_handler(self, link):
         url = str(link.get('href')).lower()
 
-        if extract_subdomain(url) not in ['www.linkedin.com']:
+        if not extract_subdomain(url).endswith('linkedin.com'):
             return False
         elif 'linkedin.com/in' not in url:
             return False


### PR DESCRIPTION
fixes #13

the html result contained international linkedin subdomains  (e.g., `it.linkedin.com`, `at.linkedin.com` etc.), which are currently skipped by CrossLinked. my PR fixes that.